### PR TITLE
Fix check of metadata.id against dvd_order list

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -838,7 +838,7 @@ class TVDBAgent(Agent.TV_Shows):
     @parallelize
     def UpdateEpisodes():
 
-      use_dvd_order = metadata.id in [int(v) for v in Prefs['dvd_order'].split(',')];
+      use_dvd_order = int(metadata.id) in [int(v) for v in Prefs['dvd_order'].split(',')];
 
       for episode_info in episode_data:
 


### PR DESCRIPTION
Needed to cast the metadata.id as an int for proper comparison against `Prefs['dvd_order']`.

My checks were failing because metadata.id was _not_ an integer when being tested for existence in the `dvd_order` list.
